### PR TITLE
[fix] - "@types/jest" version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/express": "^4.17.13",
     "@types/helmet": "^4.0.0",
     "@types/hpp": "^0.2.1",
-    "@types/jest": "^26.0.24",
+    "@types/jest": "^27.4.1",
     "@types/jsonwebtoken": "^8.5.4",
     "@types/mongoose": "^5.10.1",
     "@types/morgan": "^1.9.3",


### PR DESCRIPTION
npm ERR! While resolving: ts-jest@27.1.3
npm ERR! Found: @types/jest@26.0.24
npm ERR! node_modules/@types/jest
npm ERR!   dev @types/jest@"^26.0.24" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional @types/jest@"^27.0.0" from ts-jest@27.1.3
npm ERR! node_modules/ts-jest
npm ERR!   dev ts-jest@"^27.0.7" from the root project