### PR TITLE
Fix the webhook route path

### DIFF
--- a/server/src/routes/webhook.route.ts
+++ b/server/src/routes/webhook.route.ts
@@ -4,7 +4,7 @@ import signatureMiddleware from '@middlewares/signature.middleware';
 import WebhookController from '@controllers/webhook.controller';
 
 class IndexRoute implements Routes {
-  public path = '/webhook';
+  public path = '/api/webhook';
   public router = Router();
   public webhookController = new WebhookController();
 


### PR DESCRIPTION
I just fixed the path to the webhook route. The service couldn't reach from website cause there was no `/api/webhook` and throws an error if only sent request to `/webhook`.